### PR TITLE
Ignore lists of lists in JSON, reenable feature

### DIFF
--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -801,16 +801,28 @@ func (t Type) json(w io.Writer) {
 		fprintf(w, "err = s.WriteJSON(b);")
 		writeErrCheck(w)
 	case TYPE_LIST:
+		typ := t.List().ElementType()
+		which := typ.Which()
+		if which == TYPE_LIST || which == TYPE_OBJECT {
+			// untyped list, cant do anything but report
+			// that a field existed.
+			//
+			// s will be unused in this case, so ignore
+			fprintf(w, `_ = s;`)
+			fprintf(w, `_, err = b.WriteString("\"untyped list\"");`)
+			writeErrCheck(w)
+			return
+		}
 		fprintf(w, "{ err = b.WriteByte('[');")
 		writeErrCheck(w)
 		fprintf(w, "for i, s := range s.ToArray() {")
 		fprintf(w, `if i != 0 { _, err = b.WriteString(", "); };`)
 		writeErrCheck(w)
-		typ := t.List().ElementType()
 		typ.json(w)
 		fprintf(w, "}; err = b.WriteByte(']'); };")
 		writeErrCheck(w)
 	case TYPE_VOID:
+		fprintf(w, `_ = s;`)
 		fprintf(w, `_, err = b.WriteString("null");`)
 		writeErrCheck(w)
 	}

--- a/json.go
+++ b/json.go
@@ -2,4 +2,4 @@ package capn
 
 // JSON support for List(List(something)), e.g ZVECVEC in the aircraft.capnp, isn't finished (currently broken).
 //  We disable JSON generation to get back to a working state.
-const JSON_enabled = false
+const JSON_enabled = true


### PR DESCRIPTION
The way that lists of lists are represented in the generated code is
as an opaque pointer list. The JSON code needs a typed representation
in order to walk and print the value.

Just ignore for now. Lists of lists aren't widely used because people
have to manage the types themselves.
