### PR TITLE
Add support for output directory tree

### DIFF
--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -959,6 +960,11 @@ func main() {
 		}
 
 		assert(f.pkg != "", "missing package annotation for %s", reqf.Filename())
+
+		if dirPath, _ := filepath.Split(reqf.Filename()); dirPath != "" {
+			err := os.MkdirAll(dirPath, os.ModePerm)
+			assert(err == nil, "%v\n", err)
+		}
 
 		file, err := os.Create(reqf.Filename() + ".go")
 		assert(err == nil, "%v\n", err)


### PR DESCRIPTION
This plugin should support `--output=<lang>[:<dir>]` and nested directory structures.

Replicating the [behavior of the official C++ plugin](https://github.com/kentonv/capnproto/blob/master/c%2B%2B/src/capnp/compiler/capnpc-c%2B%2B.c%2B%2B#L1989), the patch makes sure all the directories in `RequestedFile.filename` actually exists before trying to write the content of the compiled Go source code.
