### PR TITLE
Fix integer underflow on compare function

### DIFF
--- a/capn.go
+++ b/capn.go
@@ -1227,7 +1227,7 @@ func compare(a, b rbtree.Item) int {
 	ao := a.(offset)
 	bo := b.(offset)
 	if ao.id != bo.id {
-		return int(ao.id - bo.id)
+		return int(ao.id) - int(bo.id)
 	} else if ao.boff > bo.boff {
 		return 1
 	} else if ao.boff < bo.boff {


### PR DESCRIPTION
On compare(), If 'id' field of two object is different, it returns int(ao.id - bo.id).
This may cause problem, because offset.id is unsigned 32bit integer. If ao.id < bo.id, ao.id - bo.id underflows.

I found this on copying our custom complex capn object (copying from one capn list to another capn list). tree.FindLE returned some strange iterator because of this unwanted behaviour, so writePtr raised ErrOverlap and List.Set() failed.

This patch fixes this bug.