### PR TITLE
Fix index out of bounds bug

### DIFF
--- a/capn.go
+++ b/capn.go
@@ -1436,10 +1436,11 @@ func (destSeg *Segment) writePtr(off int, src Object, copies *rbtree.Tree, depth
 			}
 		}
 
-		binary.LittleEndian.PutUint64(t.Data[len(t.Data):], srcSeg.farPtrValue(farPointer, src.off))
-		binary.LittleEndian.PutUint64(t.Data[len(t.Data)+8:], src.value(src.off-8))
+		l := len(t.Data)+16
+		binary.LittleEndian.PutUint64(t.Data[len(t.Data):l], srcSeg.farPtrValue(farPointer, src.off))
+		binary.LittleEndian.PutUint64(t.Data[len(t.Data)+8:l], src.value(src.off-8))
 		binary.LittleEndian.PutUint64(destSeg.Data[off:], t.farPtrValue(doubleFarPointer, len(t.Data)))
-		t.Data = t.Data[:len(t.Data)+16]
+		t.Data = t.Data[:l]
 		return nil
 	}
 }

--- a/capn.go
+++ b/capn.go
@@ -1418,11 +1418,11 @@ func (destSeg *Segment) writePtr(off int, src Object, copies *rbtree.Tree, depth
 		binary.LittleEndian.PutUint64(destSeg.Data[off:], srcSeg.farPtrValue(farPointer, src.off-8))
 		return nil
 
-	} else if len(srcSeg.Data)+8 <= cap(srcSeg.Data) {
+	} else if l := len(srcSeg.Data)+8; l <= cap(srcSeg.Data) {
 		// Have room in the target for a tag
-		binary.LittleEndian.PutUint64(srcSeg.Data[len(srcSeg.Data):], src.value(len(srcSeg.Data)))
+		binary.LittleEndian.PutUint64(srcSeg.Data[len(srcSeg.Data):l], src.value(len(srcSeg.Data)))
 		binary.LittleEndian.PutUint64(destSeg.Data[off:], srcSeg.farPtrValue(farPointer, len(srcSeg.Data)))
-		srcSeg.Data = srcSeg.Data[:len(srcSeg.Data)+8]
+		srcSeg.Data = srcSeg.Data[:l]
 		return nil
 
 	} else {


### PR DESCRIPTION
PutUint64 requires the slice to already have sufficient len - i.e. it writes to the slice, not appends. Previously, in this branch, the slice was not being extended, so PutUint64 would panic.