### PR TITLE
Fix buffer overlap on multi-segmented message

### DIFF
--- a/mem.go
+++ b/mem.go
@@ -156,7 +156,7 @@ func ReadFromStream(r io.Reader, buf *bytes.Buffer) (*Segment, error) {
 	m := &MultiBuffer{make([]*Segment, segnum)}
 	for i := 0; i < segnum; i++ {
 		sz := int(binary.LittleEndian.Uint32(hdrv[4*i:])) * 8
-		m.Segments[i] = &Segment{m, datav[:sz], uint32(i), false}
+		m.Segments[i] = &Segment{m, append([]byte{}, datav[:sz]...), uint32(i), false}
 		datav = datav[sz:]
 	}
 

--- a/mem.go
+++ b/mem.go
@@ -156,7 +156,7 @@ func ReadFromStream(r io.Reader, buf *bytes.Buffer) (*Segment, error) {
 	m := &MultiBuffer{make([]*Segment, segnum)}
 	for i := 0; i < segnum; i++ {
 		sz := int(binary.LittleEndian.Uint32(hdrv[4*i:])) * 8
-		m.Segments[i] = &Segment{m, append([]byte{}, datav[:sz]...), uint32(i), false}
+		m.Segments[i] = &Segment{m, datav[:sz:sz], uint32(i), false}
 		datav = datav[sz:]
 	}
 

--- a/utils2_test.go
+++ b/utils2_test.go
@@ -20,7 +20,7 @@ func init() {
 	zerohi32 = uint64(u32)
 }
 
-func CapnpEncode(msg string, typ string) []byte {
+func CapnpEncode(msg string, typ string, extra_args ...string) []byte {
 	capnpPath, err := exec.LookPath("capnp")
 	//capnpPath, err := exec.LookPath("tee")
 	if err != nil {
@@ -31,8 +31,8 @@ func CapnpEncode(msg string, typ string) []byte {
 	}
 
 	schfn := "aircraftlib/aircraft.capnp"
-	args := []string{"encode", schfn, typ}
-	cmdline := fmt.Sprintf("%s %s %s %s", capnpPath, "encode", schfn, typ)
+	args := append([]string{"encode", schfn, typ}, extra_args...)
+	cmdline := fmt.Sprintf("%s %s", capnpPath, strings.Join(args, " "))
 	//fmt.Printf("cmdline = %s\n", cmdline)
 	c := exec.Command(capnpPath, args...)
 


### PR DESCRIPTION
When reading/writing multi-segmented message, message are sometimes broken. I found this bug while parsing multi-segmented message serialized by c++ capnp library.

**How to reproduce**
1. Generate multi-segmented message somehow (ex. capnp encode --segment-size=xx) 
2. Parse given message using go-capnproto
3. Modify a text field which is not in a last segment
4. Then some random field is gone, or overall structure is broken, i.e, WriteTo() does not generate valid capnproto message.

**Root Cause**
When parsing multiple segments in ReadFromStream(), m.Segments[*] is filled by slicing one big buffer. So they share underlying memories. Thus, When Segment.Data[] grows, it overlaps with next segment, then some random memory (list or pointer maybe) are overwritten. 

**Workaround**
My workaround is to generate a new []byte for each segment. But I'm not sure this is the best, since this will allocate more memories.