### PR TITLE
Added fix to the test in Go1.13

### DIFF
--- a/create_test.go
+++ b/create_test.go
@@ -8,6 +8,12 @@ import (
 	cv "github.com/glycerine/goconvey/convey"
 )
 
+// https://github.com/golang/go/issues/31859#issuecomment-489889428
+var _ = func() bool {
+	testing.Init()
+	return true
+}()
+
 func TestCreationOfZDate(t *testing.T) {
 	const n = 1
 	packed := false


### PR DESCRIPTION
The error is produced because the testing arguments are replaced by the default arguments declared in the program startup.

[Here](https://github.com/golang/go/issues/31859#issuecomment-489889428) is the solution I implemented.